### PR TITLE
 Use App link instead of plain text on App listing page.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/apigee_edge": "^1.0-rc2"
+        "drupal/apigee_edge": "^1.0"
     }
 }

--- a/src/BetterAppListBuilder.php
+++ b/src/BetterAppListBuilder.php
@@ -56,7 +56,11 @@ class BetterAppListBuilder extends DeveloperAppListBuilderForDeveloper {
           'id' => $this->getCssIdForInfoRow($entity),
           'class' => 'row--info',
         ]),
-        'name' => $entity->label(),
+        'name' => [
+          '#type' => 'link',
+          '#title' => $entity->label(),
+          '#url' => $entity->toUrl('canonical-by-developer'),
+        ],
         'status' => $this->renderAppStatus($entity),
         'operations' => $this->buildOperations($entity),
         'warning_attributes' => new Attribute([


### PR DESCRIPTION
* Use App link instead of plain text on App listing page.

This PR also changes the `apigee_edge` module dependency to latest stable.